### PR TITLE
In case 'beginning of a multi level hash', take keys with special cha…

### DIFF
--- a/test/in_W.yml
+++ b/test/in_W.yml
@@ -1,0 +1,67 @@
+# encoding: UTF-8
+
+m_13: >
+  Não deve dar problema aqui!
+  Não deve dar problema aqui!
+  Não deve dar problema aqui!
+  Pois às vezes dá.
+
+o_15: |
+  Não deve dar problema aqui!
+  Pois às vezes dá.
+
+b_(two)²:
+  a_1: Joãozinho
+  b_two: |
+    Nos somos legais, como
+    por exemplo: João,
+    que: gosta de nos dar milhões
+    em dinheiro todos os dias.
+    
+    Linhas em Branco com tabulação
+    nos strings devem ser preservadas.
+    
+  d_four: "Somos chatos
+    gostamos de várias linhas\"
+    e ainda usamos escaping
+    para fuder"
+  e_five: Prefirimos strings sem
+    nenhum tipo de especificação.
+  c_three:
+      a: "Marcelo"
+  g_se/ ven:
+      d_4: Rafael
+      # Comentário de muitas
+      # linhas (goes with d_4)
+      "b": Bernardo
+      c_3:
+          unify: Luiz
+          klass: Lucas
+  f_six: Dalton
+a_one: José   # Comentado
+c_three: Gustavo
+# Comentário (goes with c_three)
+f_six: Thiago
+e_five:
+  b_two: Catarina
+  a_one: Rodrigo
+  # Comentário (goes with a_one)
+"g-seven": Marcelo
+d_four: Oliveira
+k_eleven: Ronaldo
+"l_other123123": Emilio
+
+i_nine: Prestes
+
+j_ten: >
+  Pior quando resolvemos escrever
+  assim, impossível aturar!
+n_14: >
+  Não deve dar problema aqui!
+  Pois às vezes dá.
+o_15: |
+  Não deve dar problema aqui!
+  Pois às vezes dá.
+p_16: Não deve dar problema aqui!
+  Pois às vezes dá.
+h_eight: "Jonivildo"

--- a/test/out_W.yml
+++ b/test/out_W.yml
@@ -1,0 +1,62 @@
+# encoding: UTF-8
+a_one: José   # Comentado
+b_(two)²:
+  a_1: Joãozinho
+  b_two: |
+    Nos somos legais, como
+    por exemplo: João,
+    que: gosta de nos dar milhões
+    em dinheiro todos os dias.
+    
+    Linhas em Branco com tabulação
+    nos strings devem ser preservadas.
+    
+  c_three:
+      a: "Marcelo"
+  d_four: "Somos chatos
+    gostamos de várias linhas\"
+    e ainda usamos escaping
+    para fuder"
+  e_five: Prefirimos strings sem
+    nenhum tipo de especificação.
+  f_six: Dalton
+  g_se/ ven:
+      "b": Bernardo
+      c_3:
+          klass: Lucas
+          unify: Luiz
+      d_4: Rafael
+      # Comentário de muitas
+      # linhas (goes with d_4)
+c_three: Gustavo
+# Comentário (goes with c_three)
+d_four: Oliveira
+e_five:
+  a_one: Rodrigo
+  # Comentário (goes with a_one)
+  b_two: Catarina
+f_six: Thiago
+"g-seven": Marcelo
+h_eight: "Jonivildo"
+i_nine: Prestes
+j_ten: >
+  Pior quando resolvemos escrever
+  assim, impossível aturar!
+k_eleven: Ronaldo
+"l_other123123": Emilio
+m_13: >
+  Não deve dar problema aqui!
+  Não deve dar problema aqui!
+  Não deve dar problema aqui!
+  Pois às vezes dá.
+n_14: >
+  Não deve dar problema aqui!
+  Pois às vezes dá.
+o_15: |
+  Não deve dar problema aqui!
+  Pois às vezes dá.
+o_15: |
+  Não deve dar problema aqui!
+  Pois às vezes dá.
+p_16: Não deve dar problema aqui!
+  Pois às vezes dá.

--- a/test/test_i18n_yaml_sorter.rb
+++ b/test/test_i18n_yaml_sorter.rb
@@ -10,6 +10,15 @@ class TestI18nYamlSorter < Test::Unit::TestCase
     end
   end
 
+  def test_should_sort_complex_sample_file_with_special_characters
+    open(File.dirname(__FILE__) + '/in_W.yml') do |file|
+      sorter = I18nYamlSorter::Sorter.new(file)
+      open(File.dirname(__FILE__) + '/out_W.yml') do |expected_out|
+        assert_equal expected_out.read, sorter.sort
+      end
+    end
+  end
+
   def test_should_rails_i18n_default_file
     open(File.dirname(__FILE__) + '/in_rails.yml') do |file|
       sorter = I18nYamlSorter::Sorter.new(file)
@@ -38,11 +47,11 @@ class TestI18nYamlSorter < Test::Unit::TestCase
       assert_equal present, future
     end
   end
-  
+
   def test_command_line_should_work_in_stdin
     output = `#{File.dirname(__FILE__)}/../bin/sort_yaml < #{File.dirname(__FILE__)}/in.yml`
     open(File.dirname(__FILE__) +  '/out.yml') do |expected_out|
-      assert_equal expected_out.read, output 
+      assert_equal expected_out.read, output
     end
   end
 end


### PR DESCRIPTION
…racters

For instance, i want to sort yaml keys like:

"Wh (ep)/Hab":
          unit: "%{n} Wh (ep)/Hab"
          thousand: "%{n} kWh (ep)/Hab"
          million: "%{n} kWh (ep)/Mab"
          billion: "%{n} kWh (ep)/Gab"
"Wh/m²/jour":
          unit: "%{n} Wh/m²/jour"
          thousand: "%{n} kWh/m²/jour"
          million: "%{n} kWh/m²/Mour"
          billion: "%{n} kWh/m²/Gour"